### PR TITLE
Fix lock_acquire for single core

### DIFF
--- a/kern/src/lock.c
+++ b/kern/src/lock.c
@@ -26,7 +26,7 @@ void lock_init(void)
 
 bool lock_acquire(bool preemptable)
 {
-	return preemptable || !preempt();
+	return !preemptable || !preempt();
 }
 
 void lock_release(void)


### PR DESCRIPTION
`lock_acquire` should return true (meaning kernel doesn't have to preempt) when preemptable is set to false.